### PR TITLE
FIX: Ensure job can actually issue notifications within 1 day

### DIFF
--- a/app/jobs/scheduled/mark_as_solution.rb
+++ b/app/jobs/scheduled/mark_as_solution.rb
@@ -2,7 +2,7 @@
 
 module Jobs
   class MarkAsSolution < ::Jobs::Scheduled
-    every 14.days
+    every 12.hours
 
     def execute(_args = nil)
       return false unless SiteSetting.solved_enabled


### PR DESCRIPTION
Currently due to the 14.day schedule, any sites with `remind_mark_solution_last_post_age` of 1 will not be able to receive notifications. This bumps the frequency to half a day.