### PR TITLE
FIX: Revert 1 day to 14 days

### DIFF
--- a/app/jobs/scheduled/mark_as_solution.rb
+++ b/app/jobs/scheduled/mark_as_solution.rb
@@ -2,7 +2,7 @@
 
 module Jobs
   class MarkAsSolution < ::Jobs::Scheduled
-    every 1.day
+    every 14.days
 
     def execute(_args = nil)
       return false unless SiteSetting.solved_enabled && SiteSetting.solved_reminders_plugin_enabled


### PR DESCRIPTION
Making the job run every day instead of 14 days violates the initial specs.

Related: 
- https://github.com/discourse/discourse-solved-reminders-plugin/pull/20
- m/342264