### PR TITLE
FIX: fix min value for setting remind_mark_solution_after_days

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,7 @@ plugins:
     client: true
   remind_mark_solution_after_days:
     default: 14
-    min: 1
+    min: 14
     max: 365
   remind_mark_solution_last_post_age:
     default: 180


### PR DESCRIPTION
Since the scheduled job runs every 14 days, currently it's not possible for setting to be lower than that.